### PR TITLE
#23: Ad-hoc plugin system for riyaz

### DIFF
--- a/riyaz/app.py
+++ b/riyaz/app.py
@@ -1,9 +1,15 @@
 from flask import Flask, abort, render_template, send_from_directory
 
 import markdown
+from typing import List
 
 from . import config
 from .db import Course, Store
+
+
+# for plugins
+stylesheet_urls: List[str] = []
+javascript_urls: List[str] = []
 
 
 app = Flask("riyaz")
@@ -51,3 +57,32 @@ def get_course_version(name: str):
 @app.route("/assets/<path:path>")
 def serve_assets(path):
     return send_from_directory(config.assets_path, path)
+
+
+@app.context_processor
+def inject_plugins():
+    return dict(
+        javascript_urls=javascript_urls,
+        stylesheet_urls=stylesheet_urls,
+    )
+
+
+# Plugin system
+
+def include_javascript(url: str):
+    javascript_urls.append(url)
+
+
+def include_stylesheet(url: str):
+    stylesheet_urls.append(url)
+
+
+if __name__ == "__main__":
+    # import plugins here to load them
+    # example:
+    # import feather_riyaz
+    #
+    # NOTE: not sure whether this works when app is served by gunicorn
+    # or some other WSGI server. it depends on how they load it
+
+    pass

--- a/riyaz/app.py
+++ b/riyaz/app.py
@@ -2,7 +2,6 @@ from flask import (
     Flask, abort, render_template, send_from_directory
 )
 
-import importlib
 import markdown
 from typing import List
 
@@ -14,9 +13,6 @@ app = Flask("riyaz")
 
 javascript_urls: List[str] = []
 stylesheet_urls: List[str] = []
-plugins: List[str] = [
-    # "feather.riyaz_plugin",
-]
 
 
 @app.template_filter("markdown")
@@ -73,15 +69,13 @@ def inject_plugins():
     )
 
 
-@app.before_request
-def load_plugins():
-    for plugin_module in plugins:
-        importlib.import_module(plugin_module)
-
-
 def include_stylesheet(url):
     stylesheet_urls.append(url)
 
 
 def include_javascript(url):
     javascript_urls.append(url)
+
+
+# import plugins here. for example:
+# import feather.riyaz_plugin

--- a/riyaz/app.py
+++ b/riyaz/app.py
@@ -1,5 +1,8 @@
-from flask import Flask, abort, render_template, send_from_directory
+from flask import (
+    Flask, abort, render_template, send_from_directory
+)
 
+import importlib
 import markdown
 from typing import List
 
@@ -7,12 +10,13 @@ from . import config
 from .db import Course, Store
 
 
-# for plugins
-stylesheet_urls: List[str] = []
-javascript_urls: List[str] = []
-
-
 app = Flask("riyaz")
+
+javascript_urls: List[str] = []
+stylesheet_urls: List[str] = []
+plugins: List[str] = [
+    # "feather.riyaz_plugin",
+]
 
 
 @app.template_filter("markdown")
@@ -59,6 +63,8 @@ def serve_assets(path):
     return send_from_directory(config.assets_path, path)
 
 
+# plugins
+
 @app.context_processor
 def inject_plugins():
     return dict(
@@ -67,22 +73,15 @@ def inject_plugins():
     )
 
 
-# Plugin system
+@app.before_request
+def load_plugins():
+    for plugin_module in plugins:
+        importlib.import_module(plugin_module)
 
-def include_javascript(url: str):
-    javascript_urls.append(url)
 
-
-def include_stylesheet(url: str):
+def include_stylesheet(url):
     stylesheet_urls.append(url)
 
 
-if __name__ == "__main__":
-    # import plugins here to load them
-    # example:
-    # import feather_riyaz
-    #
-    # NOTE: not sure whether this works when app is served by gunicorn
-    # or some other WSGI server. it depends on how they load it
-
-    pass
+def include_javascript(url):
+    javascript_urls.append(url)

--- a/riyaz/templates/base.html
+++ b/riyaz/templates/base.html
@@ -1,3 +1,11 @@
+{%- macro ExternalStylesheet(url_) %}
+<link rel="stylesheet" href="{{ href }}">
+{% endmacro -%}
+
+{%- macro ExternalScript(url_) %}
+<script src="{{ url_ }}"></script>
+{% endmacro -%}
+
 <!doctype html>
 <html lang="en">
   <head>
@@ -29,6 +37,11 @@
 
     {% block end_of_head %}
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx" crossorigin="anonymous">
+
+    {% for url_ in stylesheet_urls %}
+    {{ ExternalStylesheet(url_) }}
+    {% endfor %}
+
     {% endblock %}
   </head>
   <body>
@@ -68,6 +81,11 @@
 
     {% block end_of_body %}
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa" crossorigin="anonymous"></script>
+
+    {% for url_ in javascript_urls %}
+    {{ ExternalScript(url_) }}
+    {% endfor %}
+
     {% endblock %}
 
   </body>

--- a/riyaz/templates/base.html
+++ b/riyaz/templates/base.html
@@ -1,5 +1,5 @@
 {%- macro ExternalStylesheet(url_) %}
-<link rel="stylesheet" href="{{ href }}">
+<link rel="stylesheet" href="{{ url_ }}">
 {% endmacro -%}
 
 {%- macro ExternalScript(url_) %}


### PR DESCRIPTION
Fixes #23 

**Usage**
Create a module, import `include_javascript`, and `include_stylesheet` from `riyaz.app`.
Invoke them with URLs of the assets to be included.

Example:
```python
#-- riyaz_highlight.py
from riyaz.app import include_stylesheet, include_javascript

include_stylesheet("https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/default.min.css")
include_javascript("https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/highlight.min.js")

#-- riyaz/app.py - end of file
# import plugins here. for example:
# import feather.riyaz_plugin
import riyaz_highlight
```