### PR TITLE
#34: Add command: `riyaz new-site`

### DIFF
--- a/riyaz/cli/__init__.py
+++ b/riyaz/cli/__init__.py
@@ -76,6 +76,7 @@ def new_site(sitename):
     This can be used to host multiple courses and persist state through
     restarts.
 
+    \b
     Example usage:
     ```
     $ riyaz new-site riyaz-prod
@@ -84,6 +85,7 @@ def new_site(sitename):
     assets riyaz.db riyaz.yml
     ```
 
+    \b
     To start the server, cd into the site directory and start a WSGI server
     with entrypoint `riyaz.app:app`.
     ```

--- a/riyaz/cli/__init__.py
+++ b/riyaz/cli/__init__.py
@@ -11,6 +11,7 @@ The CLI can run these commands:
 """
 import contextlib
 import os
+import sys
 import tempfile
 from pathlib import Path
 
@@ -94,6 +95,7 @@ def new_site(sitename):
     if sitename.exists():
         click.echo(click.style(
             f"Directory {sitename} already exists", fg="red", bold=True))
+        sys.exit(1)
 
     sitename.mkdir()
     setup_db(sitename)

--- a/riyaz/cli/__init__.py
+++ b/riyaz/cli/__init__.py
@@ -15,8 +15,8 @@ import tempfile
 from pathlib import Path
 
 import click
+import yaml
 from cookiecutter.main import cookiecutter
-from click import ClickException
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 
@@ -116,5 +116,11 @@ def setup_assets(base_dir):
 
 
 def setup_config(base_dir):
-    # TODO: implement this
-    pass
+    config_path = os.path.join(base_dir, "riyaz.yml")
+    initial_config = {
+        "database_path": "riyaz.db",
+        "assets_path": "assets",
+    }
+
+    with open(config_path, "w") as f:
+        yaml.safe_dump(initial_config, f)

--- a/riyaz/config.py
+++ b/riyaz/config.py
@@ -1,4 +1,18 @@
+import yaml
+from pathlib import Path
+
 
 # path to sqlite database
 database_path = "riyaz.db"
 assets_path = "assets"
+
+
+if (config_path := Path("riyaz.yml")).exists():
+    with open(config_path, "r") as f:
+        _yml_config = yaml.safe_load(f)
+
+    if "database_path" in _yml_config:
+        database_path = _yml_config["database_path"]
+
+    if "assets_path" in _yml_config:
+        assets_path = _yml_config["assets_path"]


### PR DESCRIPTION
Fixes #34 

**Changes:**
* New command `new-site`
* Documentation for `riyaz new-site`
* `setup_config` method in `riyaz/cli/__init__.py`
* `config.py`: Read config from `./riyaz.yml` if it is present

Creates a directory structure like this:
```
newsite/
|-- assets/
|-- riyaz.db
|-- riyaz.yml
-------------
```

Initial `riyaz.yml` looks like
```
database_path: riyaz.db
assets_path: assets
```

~~Note: To work properly this depends on `config.py` parsing a `riyaz.yml` from the current working directory~~ added